### PR TITLE
fix flet "obsolete macro" warning in emacs 24.3+

### DIFF
--- a/ats2-mode.el
+++ b/ats2-mode.el
@@ -185,7 +185,7 @@
   (interactive)
   (when (null limit) (setq limit (point-max)))
   (let (foundp begin end (key-begin 0) (key-end 0) pt)
-    (flet ((store ()
+    (cl-flet ((store ()
              (store-match-data (list begin end key-begin key-end))))
       ;; attempt to find some statics to highlight and store the
       ;; points beginning and ending the region to highlight.  needs


### PR DESCRIPTION
changed 1 occurrence of flet to cl-flet to fix obsolete macro warning